### PR TITLE
Cleaning up installation and tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,39 +1,30 @@
 language: python
-sudo: false
+
 python:
-- '2.7'
-- '3.5'
+  - '2.7'
+  - '3.5'
+  - '3.6'
+  - '3.7'
 
 install:
-- if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh
-  -O miniconda.sh; else wget http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
-  -O miniconda.sh; fi
-- bash miniconda.sh -b -p $HOME/miniconda
-- export PATH="$HOME/miniconda/bin:$PATH"
-- hash -r
-- conda config --set always_yes yes --set changeps1 no
-- conda update -q conda
-- conda info -a
-- |
-  conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION pip numpy pandas pytest matplotlib scipy statsmodels pytables
-- source activate test-environment
-- conda list
-- pip install pycodestyle
-- pip install orca
-- pip install https://github.com/udst/urbansim/archive/master.zip
-- pip install osmnet pandana
-- cd .. && git clone git@github.com:urbansim/developer.git
-- pip install ./developer
-- cd $TRAVIS_BUILD_DIR && pip install .
+  - pip install https://github.com/urbansim/developer/archive/master.zip
+  - pip install .
+  - pip install -r requirements-dev.txt
+  - pip list
 
 script:
-- pycodestyle urbansim_parcels
-- pycodestyle sf_example
-- pycodestyle sd_example
-- py.test
-- cd $TRAVIS_BUILD_DIR/sf_example && python simulate.py
-- python simulate_occupancy.py
-- python simulate_pipeline.py
-- cd $TRAVIS_BUILD_DIR/sd_example && python simulate.py
-- python simulate_occupancy.py
-- python simulate_pipeline.py
+  - pycodestyle urbansim_parcels
+  - pycodestyle sd_example
+  - pycodestyle sf_example
+  - coverage run --source urbansim_parcels --module pytest --verbose
+  - cd $TRAVIS_BUILD_DIR/sd_example
+  - python simulate.py 
+  - python simulate_occupancy.py
+  - python simulate_pipeline.py
+  - cd $TRAVIS_BUILD_DIR/sf_example
+  - python simulate.py
+  - python simulate_occupancy.py
+  - python simulate_pipeline.py
+
+after_success:
+  - coverage report

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,5 @@
+# additional packages used for development and testing
+
+coverage
+pycodestyle
+pytest

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,3 @@
-# Install setuptools if not installed.
-try:
-    import setuptools
-except ImportError:
-    from ez_setup import use_setuptools
-    use_setuptools()
-
 from setuptools import setup, find_packages
 
 setup(
@@ -17,16 +10,16 @@ setup(
     classifiers=[
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.5'
+        'Programming Language :: Python :: 3.6'
+        'Programming Language :: Python :: 3.7'
     ],
     packages=find_packages(exclude=['*.tests']),
     install_requires=[
-        'numpy >= 1.1.0',
-        'pandas >= 0.16.0',
-        'orca >= 1.3.0',
-        'urbansim >= 0.1.1',
-        'developer'
-    ],
-    extras_require={
-        'pandana': ['pandana>=0.1']
-    }
+        'developer',  # install manually: https://github.com/urbansim/developer
+        'numpy',
+        'orca',
+        'pandana',
+        'pandas',
+        'urbansim',
+    ]
 )


### PR DESCRIPTION
This PR cleans up the Travis script and installation files. No substantive changes to the code.

Context is that this repo has not been in active development, and the Travis builds had stopped running because of a hiccup in the installation script.

### Changes

I rewrote the Travis script to streamline installation (matching how a user would install the package), and in the process also cleaned up `setup.py`.

### Testing

The core tests are passing, but the San Diego and San Francisco mini-models no longer run.

I haven't done any detailed diagnosis, but it looks like the API has changed for the developer model's `custom_selection()` function ([log#L877](https://travis-ci.com/urbansim/urbansim_parcels/jobs/255823883#L877)), plus something about how data is passed for network aggregations ([log#L617](https://travis-ci.com/urbansim/urbansim_parcels/jobs/255823883#L617)). I get the same errors on my Mac.

The last time these ran successfully in Travis was in June 2017: 
https://travis-ci.com/urbansim/urbansim_parcels/builds/49230838

### Next steps

Taking a straw poll of @janowicz and others -- it's still helpful to keep those mini-models runnable, right?

So perhaps @alephcero can take a look at the errors and get them working. Feel free to push more changes to this PR branch.